### PR TITLE
feat: add agent module

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,9 @@
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-opener": "^2",
         "react": "^19.1.0",
-        "react-dom": "^19.1.0"
+        "react-dom": "^19.1.0",
+        "ai": "^3.0.0",
+        "zod": "^3.23.8"
       },
       "devDependencies": {
         "@tauri-apps/cli": "^2",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "@tauri-apps/api": "^2",
-    "@tauri-apps/plugin-opener": "^2"
+    "@tauri-apps/plugin-opener": "^2",
+    "ai": "^3.0.0",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@types/react": "^19.1.8",

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -1,0 +1,58 @@
+import { generateText } from 'ai';
+import { z } from 'zod';
+import { promises as fs } from 'fs';
+import path from 'path';
+
+/**
+ * Tools available to the agent.
+ */
+export const tools = {
+  summary: {
+    description: 'Summarize the contents of a file.',
+    parameters: z.object({
+      filePath: z.string(),
+    }),
+    execute: async ({ filePath }: { filePath: string }) => {
+      const content = await fs.readFile(filePath, 'utf8');
+      const { text } = await generateText({
+        model: 'openai:gpt-4o-mini',
+        prompt: `Summarize the following text:\n\n${content}`,
+      });
+      return text;
+    },
+  },
+  createFile: {
+    description: 'Create a new file with a basic module structure.',
+    parameters: z.object({
+      filePath: z.string(),
+      content: z.string().optional(),
+    }),
+    execute: async ({
+      filePath,
+      content,
+    }: {
+      filePath: string;
+      content?: string;
+    }) => {
+      const initialContent =
+        content ?? `// ${path.basename(filePath)}\n\nexport {};\n`;
+      await fs.writeFile(filePath, initialContent, 'utf8');
+      return `Created file at ${filePath}`;
+    },
+  },
+};
+
+/**
+ * Run the agent with the provided prompt. The agent can call the tools defined
+ * above when generating its response.
+ */
+export async function runAgent(prompt: string) {
+  const result = await generateText({
+    model: 'openai:gpt-4o-mini',
+    tools,
+    prompt,
+  });
+  return result.text;
+}
+
+export type AgentTools = typeof tools;


### PR DESCRIPTION
## Summary
- add agent module with Vercel AI SDK integration
- implement summary and createFile tools
- include AI SDK dependencies

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Cannot find module 'ai')*

------
https://chatgpt.com/codex/tasks/task_e_689b3d7f60b0832f8b297414ffc9ed84